### PR TITLE
Rename neovim to pynvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is my attempt on writing a remote plugin framework without
   - `g:python3_host_prog` pointed to your python3 executable, or `echo
       exepath('python3')` is not empty.
   - [neovim python client](https://github.com/neovim/python-client) (`pip3
-      install neovim`)
+      install pynvim`)
 
 ## Use case
 
@@ -68,15 +68,15 @@ Bar()`.
 
 ```python
 # rplugin/python3/foo.py
-import neovim
+import pynvim
 
-@neovim.plugin
+@pynvim.plugin
 class Foo(object):
 
     def __init__(self, vim):
         self._vim = vim
 
-    @neovim.function("Bar", sync=True)
+    @pynvim.function("Bar", sync=True)
     def bar(self, args):
         return 'hello' + str(args)
 ```

--- a/pythonx/yarp.py
+++ b/pythonx/yarp.py
@@ -1,4 +1,4 @@
-from neovim import attach, setup_logging
+from pynvim import attach, setup_logging
 import sys
 import importlib
 from os import environ


### PR DESCRIPTION
I'm getting this error:

```
[ncm2_core@yarp] Traceback (most recent call last):
[ncm2_core@yarp]   File "/Users/mcchris/.config/nvim/plugged/nvim-yarp/pythonx/yarp.py", line 1, in <module>
[ncm2_core@yarp]     from neovim import attach, setup_logging
[ncm2_core@yarp] ModuleNotFoundError:
[ncm2_core@yarp] No module named 'neovim'
[ncm2_core@yarp] Job is dead. cmd=['/usr/local/bin/python3', '-u', '/Users/mcchris/.config/nvim/plugged/nvim-yarp/pythonx/yarp.py', '/var/folders/fb/nctk069d4rz
83p4b87b4rx_w0000gp/T/nvimAPLsQb/0', 2, 'ncm2_core']
```

When installing the latest python-client. Solved it by changing the imports. (don't know a lot of python but this seems to solve the issue)