### PR TITLE
find_spec is not python2-compatible

### DIFF
--- a/pythonx/yarp.py
+++ b/pythonx/yarp.py
@@ -1,8 +1,6 @@
-from importlib.util import find_spec
-
-if find_spec('pynvim'):
+try:
     from pynvim import attach, setup_logging
-else:
+except ImportError:
     from neovim import attach, setup_logging
 
 import sys


### PR DESCRIPTION
find_spec was introduced in python3.4. Consequently, this code can not be used with python2.7 and yarp#pyexe2 is not able to be executed appropriately. I suggest a complete avoidance of 'find module'-functions because they seem to have the tendency of being changed quite often. (See https://stackoverflow.com/questions/51491793/utility-to-check-imports-in-python-without-running-the-code-python2-7). For long-term use I suggest a simple try/except block.